### PR TITLE
Use `xsltproc` its `--stringparam` instead of `--param` in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,15 @@ easier to modify than the official XSL package.
 
 To use remotely:
 
-`xsltproc --xinclude http://bbcarchdev.github.io/docbook-html5/docbook-html5.xsl source.xml > dest.html`
+```
+xsltproc --xinclude http://bbcarchdev.github.io/docbook-html5/docbook-html5.xsl source.xml > dest.html
+```
 
 Or, if you have a local copy (for example, as a git submodule):
 
-`xsltproc --nonet --xinclude /path/to/docbook-html5.xsl source.xml > dest.html`
+```
+xsltproc --nonet --xinclude /path/to/docbook-html5.xsl source.xml > dest.html
+```
 
 There are currently two parameters supported:
 
@@ -32,4 +36,6 @@ prefix to a local path.
 
 With both parameters, a full processing command might be:
 
-`xsltproc --xinclude  --stringparam html.linksfile "file:///path/to/links.xml" --stringparam html.navfile "file:///path/to/nav.xml" /path/or/url/to/docbook-html5.xsl source.xml > dest.html`
+```
+xsltproc --xinclude  --stringparam html.linksfile "file:///path/to/links.xml" --stringparam html.navfile "file:///path/to/nav.xml" /path/or/url/to/docbook-html5.xsl source.xml > dest.html
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,4 @@ prefix to a local path.
 
 With both parameters, a full processing command might be:
 
-`xsltproc --xinclude  --param html.linksfile "'file:///path/to/links.xml'" --param html.navfile "'file:///path/to/nav.xml'" /path/or/url/to/docbook-html5.xsl source.xml > dest.html`
-
-(Note that double-quoting is used to ensure that the actual quotation marks
-are passed to `xsltproc` to indicate that the parameter value is a string).
+`xsltproc --xinclude  --stringparam html.linksfile "file:///path/to/links.xml" --stringparam html.navfile "file:///path/to/nav.xml" /path/or/url/to/docbook-html5.xsl source.xml > dest.html`


### PR DESCRIPTION
I simplified the examples a bit by replacing `xsltproc` its `--param` options with `--stringparam` in the examples in the `README.md`.

I've also changed the single backticks around the example shell commands with triple backticks to turn them into code blocks instead of inline code.